### PR TITLE
Update package version and fix return type in User.authenticate() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dippixyz/base",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Dippi SDK",
     "main": "dist/index.js",
     "files": [

--- a/src/interfaces/Dippi.ts
+++ b/src/interfaces/Dippi.ts
@@ -90,7 +90,7 @@ export interface User {
     getProfile(id: string): Promise<UserResponseBody | Error>;
     updateProfile(data: any): Promise<UserResponseBody | Error>; // TODO: Replace 'any' with the actual types of 'data'.
     createProfile(data: UserCreatePayload): Promise<UserResponseBody | Error>;
-    authenticate(data: SignInPayload): Promise<SigninResponseBody  | Error>;
+    authenticate(data: SignInPayload): Promise<UserResponseBody  | Error>;
     resetPassword(data: ResetPasswordPayload): Promise<any>;
     changePassword(data: ChangePasswordPayload): Promise<any>;
 }

--- a/src/resources/user.ts
+++ b/src/resources/user.ts
@@ -81,9 +81,9 @@ class User {
      * Authenticates a user.
      *
      * @param {SignInPayload} data - The data needed for user authentication.
-     * @returns {Promise<SigninResponseBody | Error>} A promise that resolves to the sign-in response body.
+     * @returns {Promise<UserResponseBody | Error>} A promise that resolves to the sign-in response body.
      */
-    async authenticate(data: SignInPayload): Promise<SigninResponseBody | Error> {
+    async authenticate(data: SignInPayload): Promise<UserResponseBody | Error> {
         const response = await fetch(
             `${this.client.url}/v1/auth/external-signin`,
             {


### PR DESCRIPTION
## Motivation for Change

It is necessary for consumption methods to have the ability to return an error-type interface when needed to facilitate their handling from the external side.

## How Did I Implement It?
In the user methods, a new error-type interface has been added, in which a code and error message will be returned whenever the request code is 400.

**Checklist:**
- [x] I have performed a semantic version bump
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
