### PR TITLE
Update package version and add new UserResponseBody interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dippixyz/base",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Dippi SDK",
     "main": "dist/index.js",
     "files": [

--- a/src/interfaces/Dippi.ts
+++ b/src/interfaces/Dippi.ts
@@ -53,7 +53,7 @@ export interface UserCreatePayload {
     phone: string;
 }
 
-export interface UserResponseBody {
+export interface UserData {
     id: string;
     password: string;
     name: string;
@@ -72,6 +72,13 @@ export interface UserResponseBody {
     applicationId: string;
     createdAt: Date;
     updatedAt: Date;
+}
+
+
+
+export interface UserResponseBody {
+    user: UserData;
+    walletAddres: string;
 }
 
 export interface Auth {

--- a/src/resources/user.ts
+++ b/src/resources/user.ts
@@ -3,11 +3,11 @@ import {
     UserResponseBody,
     UserCreatePayload,
     SignInPayload,
-    SigninResponseBody,
     ResetPasswordPayload,
     ChangePasswordPayload,
     Error,
 } from '../interfaces/Dippi';
+
 
 class User {
     client: Client;
@@ -84,6 +84,7 @@ class User {
      * @returns {Promise<UserResponseBody | Error>} A promise that resolves to the sign-in response body.
      */
     async authenticate(data: SignInPayload): Promise<UserResponseBody | Error> {
+        
         const response = await fetch(
             `${this.client.url}/v1/auth/external-signin`,
             {


### PR DESCRIPTION
## Motivation for Change
It is necessary for consumption methods to have the ability to return an error-type interface when needed to facilitate their handling from the external side.

## How Did I Implement It?
In the user methods, a new error-type interface has been added, in which a code and error message will be returned whenever the request code is 400.

**Checklist:**
- [x] I have performed a semantic version bump
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
