### PR TITLE
Add privateKey property to WalletUpdateResponseBody interface

### DIFF
--- a/src/interfaces/Dippi.ts
+++ b/src/interfaces/Dippi.ts
@@ -162,6 +162,7 @@ export interface WalletUpdateResponseBody {
     ownerId: string;
     createdAt: Date;
     updatedAt: Date;
+    privateKey: string;
 }
 
 export interface WalletRecoveryPayload {

--- a/src/resources/__tests__/wallets.test.ts
+++ b/src/resources/__tests__/wallets.test.ts
@@ -31,6 +31,7 @@ describe('Wallet', () => {
             ownerId: 'string',
             createdAt: new Date(),
             updatedAt: new Date(),
+            privateKey: 'string', // Add the privateKey property
         };
         expect(wallet.getWalletInfo('testId', 'testNetwork')).toBe(walletInfo);
     });


### PR DESCRIPTION
## Motivation for Change
It is necessary for consumption methods to have the ability to return an error-type interface when needed to facilitate their handling from the external side.

## How Did I Implement It?
In the user methods, a new error-type interface has been added, in which a code and error message will be returned whenever the request code is 400.

**Checklist:**
- [x] I have performed a semantic version bump
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
