### PR TITLE
Add privateKey field to WalletResponseBody interface

### DIFF
--- a/src/interfaces/Dippi.ts
+++ b/src/interfaces/Dippi.ts
@@ -148,6 +148,7 @@ export interface WalletResponseBody {
     ownerId: string;
     createdAt: Date;
     updatedAt: Date;
+    privateKey: string;
 }
 
 export interface WalletUpdatePayload {


### PR DESCRIPTION
## Motivation for Change
It is necessary for consumption methods to have the ability to return an error-type interface when needed to facilitate their handling from the external side.

## How Did I Implement It?
In the user methods, a new error-type interface has been added, in which a code and error message will be returned whenever the request code is 400.

**Checklist:**
- [x] I have performed a semantic version bump
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
